### PR TITLE
fix binarySearch overflow number

### DIFF
--- a/binarySearch.js
+++ b/binarySearch.js
@@ -6,7 +6,7 @@
  * @param {Number} key
  */
 function binarySearch(arr, low, high, key) {
-	var mid = parseInt((low + high) / 2);
+	var mid = low + (high - low) / 2 | 0;
 	if (arr[mid] === key) return mid;
 	if (arr[mid] > key) {
 		high = mid - 1;


### PR DESCRIPTION
修复二分查找溢出number问题，小数向下取整建议不使用parseInt，详情见下文
https://segmentfault.com/a/1190000012730162